### PR TITLE
Add /health and /status HTTP endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,10 @@ ENV CRAFTY_SERVER_STARTER_CONFIG=/config/config.yaml
 # Users will map their specific ports via -p or docker-compose
 EXPOSE 25565
 
+# Health check endpoint (default port 8095)
+EXPOSE 8095
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8095/health')" || exit 1
+
 ENTRYPOINT ["python", "-m", "crafty_server_starter"]
 CMD ["--config", "/config/config.yaml"]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,3 +54,10 @@ logging:
   file: "/var/log/crafty-server-starter/service.log"
   max_bytes: 10485760    # 10 MB
   backup_count: 5
+
+# ── Health endpoint ───────────────────────────────────────────
+health:
+  enabled: true           # set to false to disable
+  host: "127.0.0.1"       # bind address (use 0.0.0.0 to expose)
+  port: 8095              # GET /health and GET /status
+

--- a/crafty_server_starter/config.py
+++ b/crafty_server_starter/config.py
@@ -93,6 +93,15 @@ class LoggingConfig:
 
 
 @dataclass
+class HealthConfig:
+    """Health/status HTTP endpoint settings."""
+
+    enabled: bool = True
+    host: str = "127.0.0.1"
+    port: int = 8095
+
+
+@dataclass
 class AppConfig:
     """Top-level application configuration."""
 
@@ -101,6 +110,7 @@ class AppConfig:
     polling: PollingConfig = field(default_factory=PollingConfig)
     cooldowns: CooldownConfig = field(default_factory=CooldownConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
+    health: HealthConfig = field(default_factory=HealthConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +192,14 @@ def _load_logging(raw: dict[str, Any]) -> LoggingConfig:
     )
 
 
+def _load_health(raw: dict[str, Any]) -> HealthConfig:
+    return HealthConfig(
+        enabled=_get(raw, "enabled", bool, HealthConfig.enabled),
+        host=_get(raw, "host", str, HealthConfig.host),
+        port=_get(raw, "port", int, HealthConfig.port),
+    )
+
+
 def load_config(path: str | Path) -> AppConfig:
     """Load and validate configuration from a YAML file.
 
@@ -242,12 +260,16 @@ def load_config(path: str | Path) -> AppConfig:
     # -- Logging --
     logging_cfg = _load_logging(raw.get("logging", {}))
 
+    # -- Health --
+    health_cfg = _load_health(raw.get("health", {}))
+
     config = AppConfig(
         crafty=crafty,
         servers=servers,
         polling=polling,
         cooldowns=cooldowns,
         logging=logging_cfg,
+        health=health_cfg,
     )
 
     # Resolve the API token from the environment.

--- a/crafty_server_starter/health_server.py
+++ b/crafty_server_starter/health_server.py
@@ -1,0 +1,147 @@
+"""Lightweight HTTP health-check and status server.
+
+Exposes two endpoints:
+- GET /health  → 200 OK (for Docker HEALTHCHECK / Uptime Kuma)
+- GET /status  → 200 JSON with per-server state details
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from http import HTTPStatus
+from typing import Any
+
+from .server_state import ServerStateMachine
+
+log = logging.getLogger(__name__)
+
+
+class HealthServer:
+    """Minimal async HTTP server using stdlib asyncio streams.
+
+    Parameters
+    ----------
+    state_machines:
+        Mapping of server name → state machine (shared with IdleMonitor).
+    host:
+        Address to bind on.
+    port:
+        TCP port for the HTTP server.
+    """
+
+    def __init__(
+        self,
+        state_machines: dict[str, ServerStateMachine],
+        host: str = "127.0.0.1",
+        port: int = 8095,
+    ):
+        self._sms = state_machines
+        self._host = host
+        self._port = port
+        self._server: asyncio.Server | None = None
+        self._start_time = time.monotonic()
+
+    async def run(self, shutdown: asyncio.Event) -> None:
+        """Start the server, wait for shutdown, then close."""
+        self._start_time = time.monotonic()
+        self._server = await asyncio.start_server(
+            self._handle_request, self._host, self._port,
+        )
+        log.info("Health server listening on %s:%d", self._host, self._port)
+
+        await shutdown.wait()
+
+        self._server.close()
+        await self._server.wait_closed()
+        log.info("Health server stopped")
+
+    async def _handle_request(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Parse a minimal HTTP request and route to /health or /status."""
+        try:
+            request_line = await asyncio.wait_for(reader.readline(), timeout=5)
+            if not request_line:
+                return
+
+            parts = request_line.decode("utf-8", errors="replace").strip().split()
+            if len(parts) < 2:
+                self._send_response(writer, HTTPStatus.BAD_REQUEST, "Bad Request")
+                return
+
+            method, path = parts[0], parts[1]
+
+            # Drain remaining headers (we don't need them).
+            while True:
+                line = await asyncio.wait_for(reader.readline(), timeout=5)
+                if line in (b"\r\n", b"\n", b""):
+                    break
+
+            if method != "GET":
+                self._send_response(writer, HTTPStatus.METHOD_NOT_ALLOWED, "Method Not Allowed")
+            elif path == "/health":
+                self._send_response(writer, HTTPStatus.OK, "OK")
+            elif path == "/status":
+                body = self._build_status_json()
+                self._send_json(writer, HTTPStatus.OK, body)
+            else:
+                self._send_response(writer, HTTPStatus.NOT_FOUND, "Not Found")
+
+        except (asyncio.TimeoutError, ConnectionResetError, EOFError):
+            pass
+        except Exception:
+            log.exception("Health server request error")
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    def _build_status_json(self) -> dict[str, Any]:
+        uptime = time.monotonic() - self._start_time
+        servers: dict[str, Any] = {}
+        for name, sm in self._sms.items():
+            servers[name] = {
+                "state": sm.state.value,
+                "port": sm.cfg.listen_port,
+                "players_online": sm.last_known_online,
+                "players_max": sm.last_known_max,
+                "idle_seconds": round(sm.idle_elapsed(), 1) if sm.idle_since else None,
+                "crafty_server_id": sm.cfg.crafty_server_id,
+            }
+        return {
+            "status": "ok",
+            "uptime_seconds": round(uptime, 1),
+            "servers": servers,
+        }
+
+    @staticmethod
+    def _send_response(writer: asyncio.StreamWriter, status: HTTPStatus, body: str) -> None:
+        response = (
+            f"HTTP/1.1 {status.value} {status.phrase}\r\n"
+            f"Content-Type: text/plain\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+            f"{body}"
+        )
+        writer.write(response.encode("utf-8"))
+
+    @staticmethod
+    def _send_json(writer: asyncio.StreamWriter, status: HTTPStatus, data: dict) -> None:
+        body = json.dumps(data, indent=2)
+        response = (
+            f"HTTP/1.1 {status.value} {status.phrase}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+            f"{body}"
+        )
+        writer.write(response.encode("utf-8"))


### PR DESCRIPTION
- GET /health  200 OK (Docker HEALTHCHECK, Uptime Kuma)
- GET /status  JSON with per-server state, player counts, uptime
- Configurable via health.enabled/host/port in config.yaml
- Docker HEALTHCHECK uses stdlib urllib (no curl needed)