### PR TITLE
Add Bedrock Edition (UDP/RakNet) support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV CRAFTY_SERVER_STARTER_CONFIG=/config/config.yaml
 # Expose common Minecraft ports (override in docker-compose)
 # Users will map their specific ports via -p or docker-compose
 EXPOSE 25565
+EXPOSE 19132/udp
 
 ENTRYPOINT ["python", "-m", "crafty_server_starter"]
 CMD ["--config", "/config/config.yaml"]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,7 @@ servers:
     crafty_server_id: "5adcec83-684c-4555-a7e9-9d913203d07e"
     listen_port: 25565
     listen_host: "0.0.0.0"
+    edition: java               # "java" (TCP) or "bedrock" (UDP/RakNet)
     idle_timeout_minutes: 10
     start_timeout_seconds: 180
     motd_hibernating: "§7⏳ Server is hibernating. Connect to wake it up!"
@@ -29,10 +30,20 @@ servers:
     crafty_server_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     listen_port: 25566
     listen_host: "0.0.0.0"
+    edition: java
     idle_timeout_minutes: 15
     start_timeout_seconds: 300
     motd_hibernating: "§7⏳ Modded server sleeping. Connect to wake it!"
     kick_message: "§eModded server is booting!\n§7Please reconnect in ~2 minutes."
+
+  bedrock-survival:
+    crafty_server_id: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+    listen_port: 19132
+    listen_host: "0.0.0.0"
+    edition: bedrock            # Bedrock uses UDP (RakNet) on port 19132
+    idle_timeout_minutes: 10
+    start_timeout_seconds: 120
+    motd_hibernating: "Server hibernating - connect to wake up!"
 
 # ── Polling ─────────────────────────────────────────────────────
 polling:

--- a/crafty_server_starter/bedrock_protocol.py
+++ b/crafty_server_starter/bedrock_protocol.py
@@ -1,0 +1,117 @@
+"""Minecraft Bedrock / RakNet protocol helpers for the hibernation proxy.
+
+Implements just enough of the RakNet protocol to:
+- Respond to Unconnected Ping (0x01) with Unconnected Pong (0x1C) showing
+  the hibernation MOTD.
+- Reject connection attempts (Open Connection Request 1, 0x05) so the
+  client sees "unable to connect" — at which point we've already triggered
+  the server start on the first valid ping.
+
+Bedrock uses UDP on port 19132 (default). The protocol is documented at
+https://wiki.vg/Raknet_Protocol and https://bedrock.dev.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+
+# 16-byte offline message ID (RakNet "magic")
+RAKNET_MAGIC = bytes([
+    0x00, 0xFF, 0xFF, 0x00,
+    0xFE, 0xFE, 0xFE, 0xFE,
+    0xFD, 0xFD, 0xFD, 0xFD,
+    0x12, 0x34, 0x56, 0x78,
+])
+
+# Packet IDs
+ID_UNCONNECTED_PING = 0x01
+ID_UNCONNECTED_PONG = 0x1C
+ID_OPEN_CONNECTION_REQUEST_1 = 0x05
+ID_OPEN_CONNECTION_REPLY_1 = 0x06
+ID_OPEN_CONNECTION_REQUEST_2 = 0x07
+ID_INCOMPATIBLE_PROTOCOL = 0x19
+
+# Current RakNet protocol version used by Bedrock
+RAKNET_PROTOCOL_VERSION = 11
+
+
+def parse_unconnected_ping(data: bytes) -> tuple[int, int] | None:
+    """Parse an Unconnected Ping packet.
+
+    Returns (client_timestamp, client_guid) or None if the packet is invalid.
+    """
+    if len(data) < 33 or data[0] != ID_UNCONNECTED_PING:
+        return None
+
+    # Verify magic at offset 9
+    if data[9:25] != RAKNET_MAGIC:
+        return None
+
+    client_time = struct.unpack(">Q", data[1:9])[0]
+    client_guid = struct.unpack(">q", data[25:33])[0]
+    return client_time, client_guid
+
+
+def build_unconnected_pong(
+    client_time: int,
+    server_guid: int,
+    motd: str,
+    protocol_version: int = 729,
+    version_name: str = "1.21.80",
+    players_online: int = 0,
+    max_players: int = 20,
+    port_v4: int = 19132,
+    port_v6: int = 19133,
+) -> bytes:
+    """Build an Unconnected Pong response.
+
+    The server name string follows the Bedrock convention:
+    MCPE;motd;protocol;version;online;max;guid;motd2;gamemode;gamemodenum;port4;port6
+    """
+    server_name = ";".join([
+        "MCPE",
+        motd,
+        str(protocol_version),
+        version_name,
+        str(players_online),
+        str(max_players),
+        str(server_guid),
+        motd,            # MOTD line 2
+        "Survival",
+        "1",
+        str(port_v4),
+        str(port_v6),
+    ])
+
+    name_bytes = server_name.encode("utf-8")
+
+    buf = bytearray()
+    buf.append(ID_UNCONNECTED_PONG)
+    buf.extend(struct.pack(">Q", client_time))
+    buf.extend(struct.pack(">q", server_guid))
+    buf.extend(RAKNET_MAGIC)
+    buf.extend(struct.pack(">H", len(name_bytes)))
+    buf.extend(name_bytes)
+    return bytes(buf)
+
+
+def build_incompatible_protocol(server_guid: int) -> bytes:
+    """Build an Incompatible Protocol Version response.
+
+    This tells the client we don't support their RakNet version,
+    effectively rejecting the connection attempt gracefully.
+    """
+    buf = bytearray()
+    buf.append(ID_INCOMPATIBLE_PROTOCOL)
+    buf.append(RAKNET_PROTOCOL_VERSION)
+    buf.extend(RAKNET_MAGIC)
+    buf.extend(struct.pack(">q", server_guid))
+    return bytes(buf)
+
+
+def is_open_connection_request_1(data: bytes) -> bool:
+    """Check if a packet is an Open Connection Request 1."""
+    if len(data) < 25 or data[0] != ID_OPEN_CONNECTION_REQUEST_1:
+        return False
+    return data[1:17] == RAKNET_MAGIC

--- a/crafty_server_starter/bedrock_proxy.py
+++ b/crafty_server_starter/bedrock_proxy.py
@@ -1,0 +1,215 @@
+"""Async UDP proxy listener for hibernating Minecraft Bedrock servers.
+
+Handles the RakNet "unconnected" protocol layer:
+- Unconnected Ping → responds with Unconnected Pong (custom MOTD)
+- Open Connection Request 1 → triggers server start via Crafty API,
+  then responds with Incompatible Protocol to reject the connection
+  gracefully while the real server is starting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+
+from .bedrock_protocol import (
+    build_incompatible_protocol,
+    build_unconnected_pong,
+    is_open_connection_request_1,
+    parse_unconnected_ping,
+)
+from .crafty_api import CraftyApiClient
+from .server_state import ServerStateMachine, State
+
+log = logging.getLogger(__name__)
+
+
+class BedrockProxyProtocol(asyncio.DatagramProtocol):
+    """UDP protocol handler for a single Bedrock server proxy."""
+
+    def __init__(
+        self,
+        name: str,
+        sm: ServerStateMachine,
+        crafty_api: CraftyApiClient,
+        manager: BedrockProxyManager,
+    ):
+        self._name = name
+        self._sm = sm
+        self._api = crafty_api
+        self._manager = manager
+        self._server_guid = random.getrandbits(63)
+        self._transport: asyncio.DatagramTransport | None = None
+
+    def connection_made(self, transport: asyncio.DatagramTransport) -> None:
+        self._transport = transport
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        """Handle incoming UDP datagrams."""
+        if not data:
+            return
+
+        # Unconnected Ping — respond with MOTD pong
+        parsed = parse_unconnected_ping(data)
+        if parsed is not None:
+            client_time, _ = parsed
+
+            # Strip Minecraft formatting codes for Bedrock MOTD
+            motd = self._sm.cfg.motd_hibernating
+            # Remove § color codes (Bedrock uses § too but simpler text is safer)
+            clean_motd = ""
+            skip_next = False
+            for ch in motd:
+                if ch == "§":
+                    skip_next = True
+                    continue
+                if skip_next:
+                    skip_next = False
+                    continue
+                clean_motd += ch
+
+            pong = build_unconnected_pong(
+                client_time=client_time,
+                server_guid=self._server_guid,
+                motd=clean_motd or "Server hibernating",
+                players_online=0,
+                max_players=self._sm.last_known_max,
+                port_v4=self._sm.cfg.listen_port,
+            )
+            self._transport.sendto(pong, addr)
+            return
+
+        # Open Connection Request 1 — someone is trying to connect
+        if is_open_connection_request_1(data):
+            log.info(
+                "Bedrock connection attempt on port %d from %s — triggering wake-up for '%s'",
+                self._sm.cfg.listen_port, addr[0], self._name,
+            )
+
+            # Reject with Incompatible Protocol (graceful rejection)
+            reject = build_incompatible_protocol(self._server_guid)
+            self._transport.sendto(reject, addr)
+
+            # Trigger server start
+            if self._sm.state in (State.STOPPED, State.CRASHED):
+                asyncio.ensure_future(self._manager.trigger_start(self._name))
+            return
+
+    def error_received(self, exc: Exception) -> None:
+        log.warning("Bedrock proxy UDP error on '%s': %s", self._name, exc)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        pass
+
+
+class BedrockProxyManager:
+    """Manages UDP proxy listeners for Bedrock servers.
+
+    Mirrors the ProxyManager API but uses UDP (DatagramProtocol) instead
+    of TCP (start_server).
+    """
+
+    def __init__(
+        self,
+        state_machines: dict[str, ServerStateMachine],
+        crafty_api: CraftyApiClient,
+    ):
+        self._sms = state_machines
+        self._api = crafty_api
+        self._transports: dict[str, asyncio.DatagramTransport | None] = {
+            name: None for name in state_machines
+        }
+        self._start_lockout: set[str] = set()
+
+    async def run(self, shutdown: asyncio.Event) -> None:
+        """Run the Bedrock proxy manager until shutdown."""
+        log.info("Bedrock proxy manager starting (%d servers)", len(self._sms))
+        while not shutdown.is_set():
+            await self.ensure_listeners()
+            try:
+                await asyncio.wait_for(shutdown.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                pass
+
+        # Cleanup
+        for name in list(self._transports):
+            await self._stop_listener(name)
+        log.info("Bedrock proxy manager stopped")
+
+    async def ensure_listeners(self) -> None:
+        """Start/stop UDP listeners based on server state."""
+        for name, sm in self._sms.items():
+            # Respect start lockout
+            if name in self._start_lockout:
+                if sm.state in (State.STOPPED, State.CRASHED):
+                    self._start_lockout.discard(name)
+                    log.info("Bedrock start lockout cleared for '%s' (state=%s)", name, sm.state.value)
+                else:
+                    continue
+
+            if sm.is_proxy_needed and self._transports.get(name) is None:
+                await self._start_listener(name)
+            elif not sm.is_proxy_needed and self._transports.get(name) is not None:
+                await self._stop_listener(name)
+
+    async def _start_listener(self, name: str) -> None:
+        """Bind a UDP listener for the given server."""
+        sm = self._sms[name]
+        loop = asyncio.get_running_loop()
+        try:
+            transport, _ = await loop.create_datagram_endpoint(
+                lambda: BedrockProxyProtocol(name, sm, self._api, self),
+                local_addr=(sm.cfg.listen_host, sm.cfg.listen_port),
+            )
+            self._transports[name] = transport
+            log.info(
+                "Bedrock proxy listening on %s:%d for '%s'",
+                sm.cfg.listen_host, sm.cfg.listen_port, name,
+            )
+        except OSError as exc:
+            log.error(
+                "Cannot bind Bedrock proxy on %s:%d for '%s': %s",
+                sm.cfg.listen_host, sm.cfg.listen_port, name, exc,
+            )
+
+    async def _stop_listener(self, name: str) -> None:
+        """Close the UDP listener for the given server."""
+        transport = self._transports.get(name)
+        if transport is not None:
+            transport.close()
+            self._transports[name] = None
+            log.info(
+                "Bedrock proxy stopped for '%s' (port %d)",
+                name, self._sms[name].cfg.listen_port,
+            )
+
+    async def trigger_start(self, name: str) -> None:
+        """Start a Bedrock server via Crafty API."""
+        sm = self._sms.get(name)
+        if sm is None:
+            return
+
+        if name in self._start_lockout:
+            return
+
+        # Stop the UDP listener to free the port
+        await self._stop_listener(name)
+
+        # Lock out re-binding
+        self._start_lockout.add(name)
+
+        # Give OS time to release the port
+        await asyncio.sleep(5)
+
+        try:
+            await self._api.start_server(sm.cfg.crafty_server_id)
+            sm.transition(State.STARTING)
+            log.info(
+                "Bedrock port %d released and start_server sent for '%s' (lockout active)",
+                sm.cfg.listen_port, name,
+            )
+        except Exception:
+            log.exception("Failed to start Bedrock server '%s' via Crafty API", name)
+            self._start_lockout.discard(name)
+            await self._start_listener(name)

--- a/crafty_server_starter/config.py
+++ b/crafty_server_starter/config.py
@@ -54,6 +54,7 @@ class ServerConfig:
     crafty_server_id: str
     listen_port: int
     listen_host: str = "0.0.0.0"
+    edition: str = "java"  # "java" or "bedrock"
     idle_timeout_minutes: int = 10
     start_timeout_seconds: int = 180
     motd_hibernating: str = "§7⏳ Server is hibernating. Connect to wake it up!"
@@ -143,11 +144,15 @@ def _load_server(name: str, raw: dict[str, Any]) -> ServerConfig:
     port = raw.get("listen_port")
     if port is None:
         raise ConfigError(f"Server '{name}': 'listen_port' is required.")
+    edition = _get(raw, "edition", str, ServerConfig.edition).lower()
+    if edition not in ("java", "bedrock"):
+        raise ConfigError(f"Server '{name}': edition must be 'java' or 'bedrock', got '{edition}'.")
     return ServerConfig(
         name=name,
         crafty_server_id=str(cid),
         listen_port=int(port),
         listen_host=_get(raw, "listen_host", str, ServerConfig.listen_host),
+        edition=edition,
         idle_timeout_minutes=_get(raw, "idle_timeout_minutes", int, ServerConfig.idle_timeout_minutes),
         start_timeout_seconds=_get(raw, "start_timeout_seconds", int, ServerConfig.start_timeout_seconds),
         motd_hibernating=_get(raw, "motd_hibernating", str, ServerConfig.motd_hibernating),


### PR DESCRIPTION
- New bedrock_protocol.py: RakNet Unconnected Ping/Pong and connection rejection protocol helpers
- New bedrock_proxy.py: UDP proxy manager with same lockout mechanism as the Java TCP proxy
- Per-server 'edition' field: 'java' (default, TCP) or 'bedrock' (UDP)
- Bedrock proxy shows custom MOTD in server list and rejects connection attempts while triggering server wake-up
- Dockerfile exposes 19132/udp
- Example config includes a Bedrock server entry